### PR TITLE
Feat: Create Entities for Medical Appointment System

### DIFF
--- a/src/main/java/com/sebastian/clinicbooking/ClinicbookingApplication.java
+++ b/src/main/java/com/sebastian/clinicbooking/ClinicbookingApplication.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.servers.Server;
 )
 @SpringBootApplication
 public class ClinicbookingApplication {
-
 	
 	public static void main(String[] args) {
 		SpringApplication.run(ClinicbookingApplication.class, args);

--- a/src/main/java/com/sebastian/clinicbooking/enums/AppointmentStatus.java
+++ b/src/main/java/com/sebastian/clinicbooking/enums/AppointmentStatus.java
@@ -1,0 +1,14 @@
+package com.sebastian.clinicbooking.enums;
+
+public enum AppointmentStatus {
+    PENDING,
+    CONFIRMED,
+    CANCELLED,
+    COMPLETED,
+    NO_SHOW,
+    RESCHEDULED,
+    WAITLISTED,
+    IN_PROGRESS,
+    CHECKED_IN,
+    CHECKED_OUT;
+}

--- a/src/main/java/com/sebastian/clinicbooking/enums/DayOfWeek.java
+++ b/src/main/java/com/sebastian/clinicbooking/enums/DayOfWeek.java
@@ -1,0 +1,11 @@
+package com.sebastian.clinicbooking.enums;
+
+public enum DayOfWeek {
+    MONDAY,
+    TUESDAY,
+    WEDNESDAY,
+    THURSDAY,
+    FRIDAY,
+    SATURDAY,
+    SUNDAY;
+}

--- a/src/main/java/com/sebastian/clinicbooking/enums/Gender.java
+++ b/src/main/java/com/sebastian/clinicbooking/enums/Gender.java
@@ -1,0 +1,7 @@
+package com.sebastian.clinicbooking.enums;
+
+public enum Gender {
+    MALE,
+    FEMALE,
+    OTHER
+}

--- a/src/main/java/com/sebastian/clinicbooking/enums/Roles.java
+++ b/src/main/java/com/sebastian/clinicbooking/enums/Roles.java
@@ -1,0 +1,8 @@
+package com.sebastian.clinicbooking.enums;
+
+public enum Roles {
+    ADMIN,
+    DOCTOR,
+    PATIENT,
+    CLINIC
+}

--- a/src/main/java/com/sebastian/clinicbooking/model/Address.java
+++ b/src/main/java/com/sebastian/clinicbooking/model/Address.java
@@ -1,0 +1,55 @@
+package com.sebastian.clinicbooking.model;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "addresses")
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class Address {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "street", nullable = false)
+    private String street;
+
+    @Column(name = "number", nullable = false)
+    private String number;
+
+    @Column(name = "city", nullable = false)
+    private String city;
+
+    @Column(name = "state", nullable = false)
+    private String state;
+
+    @Column(name = "country", nullable = false)
+    private String country;
+
+    @Column(name = "zip_code", nullable = false)
+    private String zipCode;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+    
+}

--- a/src/main/java/com/sebastian/clinicbooking/model/Appointment.java
+++ b/src/main/java/com/sebastian/clinicbooking/model/Appointment.java
@@ -1,0 +1,88 @@
+package com.sebastian.clinicbooking.model;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import com.sebastian.clinicbooking.enums.AppointmentStatus;
+import com.sebastian.clinicbooking.enums.Roles;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Table(name = "appointments")
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class Appointment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private AppointmentStatus status;
+
+    @Column(name = "appointment_date_time", nullable = false)
+    private LocalDateTime appointmentDateTime;
+
+    @Column(name = "reason_for_visit", nullable = false)
+    private String reasonForVisit;
+
+    @Column(name = "notes")
+    private String notes;
+
+    @Column(name = "confirmed", nullable = false)
+    private boolean confirmed;
+
+    @ManyToOne
+    @JoinColumn(name = "doctor_id")
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private Doctor doctor;
+
+    @ManyToOne
+    @JoinColumn(name = "patient_id")
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private Patient patient;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "cancelled_by")
+    private Roles canceledBy;
+
+    @Column(name = "cancellation_date")
+    private LocalDateTime cancellationDate;
+
+    @Column(name = "cancellation_reason")
+    private String cancellationReason;
+
+    @ManyToOne
+    @JoinColumn(name = "rescheduled_from_id", referencedColumnName = "id")
+    private Appointment rescheduledFrom;
+
+}
+

--- a/src/main/java/com/sebastian/clinicbooking/model/Clinic.java
+++ b/src/main/java/com/sebastian/clinicbooking/model/Clinic.java
@@ -1,0 +1,40 @@
+package com.sebastian.clinicbooking.model;
+
+import java.util.List;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Table(name = "clinics")
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class Clinic extends User{
+
+    @Column(name = "name", nullable = false, unique = true)
+    private String name;
+
+    @OneToOne
+    @JoinColumn(name = "address_id", referencedColumnName = "id")
+    private Address address;
+
+    @Column(name = "contact_email", nullable = false, unique = true)
+    private String contactEmail;
+
+    @Column(name = "description")
+    private String description;
+
+    @OneToMany(mappedBy = "clinic")
+    @ToString.Exclude
+    private List<Doctor> doctors;
+}

--- a/src/main/java/com/sebastian/clinicbooking/model/Doctor.java
+++ b/src/main/java/com/sebastian/clinicbooking/model/Doctor.java
@@ -1,0 +1,66 @@
+package com.sebastian.clinicbooking.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "doctors")
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class Doctor extends User {
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "last_name", nullable = false)
+    private String lastName;
+
+    @Column(name = "license_number", nullable = false, unique = true)
+    private String licenseNumber;
+
+    @Column(name = "identification_number", nullable = false, unique = true)
+    private String identificationNumber;
+
+    @Column(name = "biography")
+    private String biography;
+
+    @ManyToMany
+    @JoinTable(
+        name = "doctor_specialization",
+        joinColumns = @JoinColumn(name = "doctor_id"),
+        inverseJoinColumns = @JoinColumn(name = "specialization_id")
+    )
+    private List<Speciality> specializations;
+
+    @ManyToMany
+    @JoinTable(
+        name = "doctor_insurance",
+        joinColumns = @JoinColumn(name = "doctor_id"),
+        inverseJoinColumns = @JoinColumn(name = "insurance_id")
+    )
+    private List<HealthInsurance> insurances;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "clinic_id")
+    private Clinic clinic;
+
+    @OneToMany(mappedBy = "doctor", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Appointment> appointments = new ArrayList<>();
+    
+}

--- a/src/main/java/com/sebastian/clinicbooking/model/DoctorAvailability.java
+++ b/src/main/java/com/sebastian/clinicbooking/model/DoctorAvailability.java
@@ -1,0 +1,58 @@
+package com.sebastian.clinicbooking.model;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "doctors_availabilities")
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class DoctorAvailability {
+    
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private Doctor doctor;
+
+    @Enumerated(EnumType.STRING)
+    private DayOfWeek dayOfWeek;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    @Column(name = "duration_in_minutes", nullable = false)
+    private Integer durationInMinutes;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "active", nullable = false)
+    private boolean active = true;
+}

--- a/src/main/java/com/sebastian/clinicbooking/model/HealthInsurance.java
+++ b/src/main/java/com/sebastian/clinicbooking/model/HealthInsurance.java
@@ -1,0 +1,48 @@
+package com.sebastian.clinicbooking.model;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "health_insurances")
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class HealthInsurance {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, unique = true)
+    private String name;
+
+    @ManyToMany(mappedBy = "insurances", fetch = FetchType.LAZY)
+    private List<Doctor> doctors;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "active", nullable = false)
+    private boolean active = true;
+}

--- a/src/main/java/com/sebastian/clinicbooking/model/Patient.java
+++ b/src/main/java/com/sebastian/clinicbooking/model/Patient.java
@@ -1,0 +1,59 @@
+package com.sebastian.clinicbooking.model;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.sebastian.clinicbooking.enums.Gender;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "patients")
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class Patient extends User {
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "last_name", nullable = false)
+    private String lastName;
+
+    @Column(name = "identification_number", nullable = false, unique = true)
+    private String identificationNumber;
+
+    @Column(name = "birth_day", nullable = false)
+    private LocalDate birthDate;
+    
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = "patient_insurance",
+        joinColumns = @JoinColumn(name = "patient_id"),
+        inverseJoinColumns = @JoinColumn(name = "insurance_id")
+    )
+    private List<HealthInsurance> insurances = new ArrayList<>();
+
+    @OneToMany(mappedBy = "patient", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Appointment> appointments = new ArrayList<>();
+    
+}

--- a/src/main/java/com/sebastian/clinicbooking/model/Speciality.java
+++ b/src/main/java/com/sebastian/clinicbooking/model/Speciality.java
@@ -1,0 +1,46 @@
+package com.sebastian.clinicbooking.model;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "specialities")
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class Speciality {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, unique = true)
+    private String name;
+
+    @ManyToMany(mappedBy = "specializations", fetch = FetchType.LAZY)
+    private List<Doctor> doctors;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+    
+}

--- a/src/main/java/com/sebastian/clinicbooking/model/User.java
+++ b/src/main/java/com/sebastian/clinicbooking/model/User.java
@@ -1,0 +1,77 @@
+package com.sebastian.clinicbooking.model;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import com.sebastian.clinicbooking.enums.Roles;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Inheritance(strategy = InheritanceType.JOINED)
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "email", nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "phone_number", nullable = false, unique = true)
+    private String phoneNumber;
+
+    @Column(name = "profile_picture_url")
+    private String profilePictureUrl;
+
+    @Enumerated(EnumType.STRING)
+    private Roles role;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "active", nullable = false)
+    private boolean active = true;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        User user = (User) o;
+        return Objects.equals(email, user.email);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(email);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=clinicbooking
-spring.datasource.url:${DB_URL}
+spring.datasource.url:jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
 spring.datasource.username:${DB_USERNAME}
 spring.datasource.password:${DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## Create Entities for Medical Appointment System

This PR involves refining and improving the entity models for the medical appointment system. We defined entities such as Appointment, Clinic, Doctor, Patient, HealthInsurance, Speciality, and DoctorAvailability, ensuring appropriate relationships, annotations, and fields. Key improvements include:

- Defining proper associations (e.g., ManyToOne, OneToMany, ManyToMany).

- Adding fields for appointment statuses, doctor availability, and health insurance.

- Implementing @CreationTimestamp and @UpdateTimestamp for automatic tracking of entity lifecycle.

- Ensuring referential integrity through JoinColumn and JoinTable mappings.

These changes align the system with the required business logic, ensuring data consistency and enabling smooth interaction between entities.