### PR TITLE
Entity Refactoring and DTO Mappers Creation

### DIFF
--- a/src/main/java/com/sebastian/clinicbooking/DTO/address/AddressRequestDTO.java
+++ b/src/main/java/com/sebastian/clinicbooking/DTO/address/AddressRequestDTO.java
@@ -1,4 +1,4 @@
-package com.sebastian.clinicbooking.DTO.addres;
+package com.sebastian.clinicbooking.DTO.address;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;

--- a/src/main/java/com/sebastian/clinicbooking/DTO/address/AddressResponseDTO.java
+++ b/src/main/java/com/sebastian/clinicbooking/DTO/address/AddressResponseDTO.java
@@ -1,4 +1,4 @@
-package com.sebastian.clinicbooking.DTO.addres;
+package com.sebastian.clinicbooking.DTO.address;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/sebastian/clinicbooking/DTO/appointment/AppointmentRequestDTO.java
+++ b/src/main/java/com/sebastian/clinicbooking/DTO/appointment/AppointmentRequestDTO.java
@@ -30,5 +30,8 @@ public class AppointmentRequestDTO {
 
     @NotNull(message = "Patient ID cannot be null")
     private Long patientId;
+
+    @NotNull(message = "Clinic ID cannot be null")
+    private Long clinicId;
     
 }

--- a/src/main/java/com/sebastian/clinicbooking/DTO/appointment/AppointmentResponseDTO.java
+++ b/src/main/java/com/sebastian/clinicbooking/DTO/appointment/AppointmentResponseDTO.java
@@ -2,6 +2,7 @@ package com.sebastian.clinicbooking.DTO.appointment;
 
 import java.time.LocalDateTime;
 
+import com.sebastian.clinicbooking.DTO.clinic.ClinicSummaryDTO;
 import com.sebastian.clinicbooking.DTO.doctor.DoctorSummaryDTO;
 import com.sebastian.clinicbooking.DTO.patient.PatientSummaryDTO;
 import com.sebastian.clinicbooking.enums.AppointmentStatus;
@@ -23,6 +24,7 @@ public class AppointmentResponseDTO {
     private boolean confirmed;
     private DoctorSummaryDTO doctor;
     private PatientSummaryDTO patient;
+    private ClinicSummaryDTO clinicName;
     private LocalDateTime createdAt;
     private CancellationInfoDTO cancellationInfo;
 }

--- a/src/main/java/com/sebastian/clinicbooking/DTO/clinic/ClinicRequestDTO.java
+++ b/src/main/java/com/sebastian/clinicbooking/DTO/clinic/ClinicRequestDTO.java
@@ -1,7 +1,7 @@
 package com.sebastian.clinicbooking.DTO.clinic;
 
 
-import com.sebastian.clinicbooking.DTO.addres.AddressRequestDTO;
+import com.sebastian.clinicbooking.DTO.address.AddressRequestDTO;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;

--- a/src/main/java/com/sebastian/clinicbooking/DTO/clinic/ClinicSummaryDTO.java
+++ b/src/main/java/com/sebastian/clinicbooking/DTO/clinic/ClinicSummaryDTO.java
@@ -1,8 +1,5 @@
 package com.sebastian.clinicbooking.DTO.clinic;
 
-import com.sebastian.clinicbooking.DTO.address.AddressResponseDTO;
-import com.sebastian.clinicbooking.enums.Roles;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,16 +7,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-public class ClinicResponseDTO {
+public class ClinicSummaryDTO {
 
     private Long id;
     private String name;
     private String contactEmail;
-    private String email;
     private String phoneNumber;
-    private AddressResponseDTO address;
-    private String description;
-    private String profilePictureUrl;
-    private Roles role;
     private boolean active;
 }

--- a/src/main/java/com/sebastian/clinicbooking/DTO/doctor/DoctorWithAppointmentDTO.java
+++ b/src/main/java/com/sebastian/clinicbooking/DTO/doctor/DoctorWithAppointmentDTO.java
@@ -1,4 +1,4 @@
-package com.sebastian.clinicbooking.DTO.patient;
+package com.sebastian.clinicbooking.DTO.doctor;
 
 import java.util.List;
 
@@ -11,11 +11,12 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-public class PatientWithAppointment {
-
+public class DoctorWithAppointmentDTO {
+    
     private Long id;
     private String name;
     private String lastName;
-    private String identificationNumber;
+    private String licenseNumber;
+    private String profilePictureUrl;
     private List <AppointmentResponseDTO> appointments;
 }

--- a/src/main/java/com/sebastian/clinicbooking/DTO/patient/PatientWithAppointmentDTO.java
+++ b/src/main/java/com/sebastian/clinicbooking/DTO/patient/PatientWithAppointmentDTO.java
@@ -1,4 +1,4 @@
-package com.sebastian.clinicbooking.DTO.doctor;
+package com.sebastian.clinicbooking.DTO.patient;
 
 import java.util.List;
 
@@ -11,12 +11,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-public class DoctorWithAppointment {
-    
+public class PatientWithAppointmentDTO {
+
     private Long id;
     private String name;
     private String lastName;
-    private String licenseNumber;
-    private String profilePictureUrl;
+    private String identificationNumber;
     private List <AppointmentResponseDTO> appointments;
 }

--- a/src/main/java/com/sebastian/clinicbooking/mapper/AddressMapper.java
+++ b/src/main/java/com/sebastian/clinicbooking/mapper/AddressMapper.java
@@ -1,0 +1,33 @@
+package com.sebastian.clinicbooking.mapper;
+
+import java.util.List;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import com.sebastian.clinicbooking.DTO.address.AddressRequestDTO;
+import com.sebastian.clinicbooking.DTO.address.AddressResponseDTO;
+import com.sebastian.clinicbooking.model.Address;
+
+@Mapper(componentModel = "spring")
+public interface AddressMapper {
+
+    Address toEntity(AddressRequestDTO dto);
+
+    AddressResponseDTO toDto(Address address);
+
+    List<AddressResponseDTO> toDtoList(List<Address> addresses);
+
+    default Page<AddressResponseDTO> toDtoPage(Page<Address> page) {
+        List<AddressResponseDTO> dtoList = toDtoList(page.getContent());
+        return new PageImpl<>(dtoList, page.getPageable(), page.getTotalElements());
+    }
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateEntityFromDto(AddressRequestDTO dto, @MappingTarget Address address);
+    
+}

--- a/src/main/java/com/sebastian/clinicbooking/mapper/AdministratorMapper.java
+++ b/src/main/java/com/sebastian/clinicbooking/mapper/AdministratorMapper.java
@@ -1,0 +1,32 @@
+package com.sebastian.clinicbooking.mapper;
+
+import java.util.List;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import com.sebastian.clinicbooking.DTO.administrator.AdministratorRequestDTO;
+import com.sebastian.clinicbooking.DTO.administrator.AdministratorResponseDTO;
+import com.sebastian.clinicbooking.model.Administrator;
+
+@Mapper(componentModel = "spring")
+public interface AdministratorMapper {
+    
+    Administrator toEntity(AdministratorRequestDTO dto);
+
+    AdministratorResponseDTO toDto(Administrator administrator);
+
+    List<AdministratorResponseDTO> toDtoList(List<Administrator> administrators);
+
+    default Page<AdministratorResponseDTO> toDtoPage(Page<Administrator> page) {
+        List<AdministratorResponseDTO> dtoList = toDtoList(page.getContent());
+        return new PageImpl<>(dtoList, page.getPageable(), page.getTotalElements());
+    }
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateEntityFromDto(AdministratorRequestDTO dto, @MappingTarget Administrator administrator);
+}

--- a/src/main/java/com/sebastian/clinicbooking/mapper/AppointmentMapper.java
+++ b/src/main/java/com/sebastian/clinicbooking/mapper/AppointmentMapper.java
@@ -1,0 +1,38 @@
+package com.sebastian.clinicbooking.mapper;
+
+import java.util.List;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import com.sebastian.clinicbooking.DTO.appointment.AppointmentRequestDTO;
+import com.sebastian.clinicbooking.DTO.appointment.AppointmentResponseDTO;
+import com.sebastian.clinicbooking.model.Appointment;
+
+@Mapper(componentModel = "spring", uses = {
+    PatientMapper.class,
+    ClinicMapper.class,
+    DoctorMapper.class,
+})
+public interface AppointmentMapper {
+    
+
+    Appointment toEntity(AppointmentRequestDTO dto);
+
+    AppointmentResponseDTO toDto(Appointment appointment);
+
+    List <AppointmentResponseDTO> toDtoList(List<Appointment> appointments);
+
+    default Page<AppointmentResponseDTO> toDtoPage(Page<Appointment> page) {
+        List<AppointmentResponseDTO> dtoList = toDtoList(page.getContent());
+        return new PageImpl<>(dtoList, page.getPageable(), page.getTotalElements());
+    }
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateEntityFromDto(AppointmentRequestDTO dto, @MappingTarget Appointment appointment);
+
+}

--- a/src/main/java/com/sebastian/clinicbooking/mapper/ClinicMapper.java
+++ b/src/main/java/com/sebastian/clinicbooking/mapper/ClinicMapper.java
@@ -1,0 +1,53 @@
+package com.sebastian.clinicbooking.mapper;
+
+import java.util.List;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import com.sebastian.clinicbooking.DTO.clinic.ClinicRequestDTO;
+import com.sebastian.clinicbooking.DTO.clinic.ClinicResponseDTO;
+import com.sebastian.clinicbooking.DTO.clinic.ClinicSummaryDTO;
+import com.sebastian.clinicbooking.DTO.clinic.ClinicWithDoctorsDTO;
+import com.sebastian.clinicbooking.model.Clinic;
+
+@Mapper(componentModel = "spring", uses = DoctorMapper.class)
+public interface ClinicMapper {
+
+    Clinic toEntity(ClinicRequestDTO dto);
+
+    ClinicResponseDTO toDto(Clinic clinic);
+
+    ClinicWithDoctorsDTO toDtoWithDoctors(Clinic clinic);
+
+    ClinicSummaryDTO toSummaryDto(Clinic clinic);
+    
+    List<ClinicResponseDTO> toDtoList(List<Clinic> clinics);
+
+    List<ClinicWithDoctorsDTO> toWithDoctorDtoList(List<Clinic> clinics);
+
+    List<ClinicSummaryDTO> toSummaryDtoList(List<Clinic> clinics);
+
+    default Page<ClinicResponseDTO> toDtoPage(Page<Clinic> page) {
+        List<ClinicResponseDTO> dtoList = toDtoList(page.getContent());
+        return new PageImpl<>(dtoList, page.getPageable(), page.getTotalElements());
+    }
+
+    default Page<ClinicWithDoctorsDTO> toWithDoctorDtoPage(Page<Clinic> page) {
+        List<ClinicWithDoctorsDTO> dtoList = toWithDoctorDtoList(page.getContent());
+        return new PageImpl<>(dtoList, page.getPageable(), page.getTotalElements());
+    }
+
+    default Page<ClinicSummaryDTO> toSummaryDtoPage(Page<Clinic> page) {
+        List<ClinicSummaryDTO> dtoList = toSummaryDtoList(page.getContent());
+        return new PageImpl<>(dtoList, page.getPageable(), page.getTotalElements());
+    }
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateEntityFromDto(ClinicRequestDTO dto, @MappingTarget Clinic clinic);
+}
+

--- a/src/main/java/com/sebastian/clinicbooking/mapper/DoctorAvailabilityMapper.java
+++ b/src/main/java/com/sebastian/clinicbooking/mapper/DoctorAvailabilityMapper.java
@@ -1,0 +1,34 @@
+package com.sebastian.clinicbooking.mapper;
+
+import java.util.List;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import com.sebastian.clinicbooking.DTO.doctorAvailability.DoctorAvailabilityRequestDTO;
+import com.sebastian.clinicbooking.DTO.doctorAvailability.DoctorAvailabilityResponseDTO;
+import com.sebastian.clinicbooking.model.DoctorAvailability;
+
+@Mapper(componentModel = "spring", uses = {
+    DoctorMapper.class,
+})
+public interface DoctorAvailabilityMapper {
+    
+    DoctorAvailability toEntity(DoctorAvailabilityRequestDTO dto);
+
+    DoctorAvailabilityResponseDTO toDto(DoctorAvailability doctorAvailability);
+
+    List<DoctorAvailabilityResponseDTO> toDtoList(List<DoctorAvailability> doctorAvailabilities);
+
+    default Page<DoctorAvailabilityResponseDTO> toDtoPage(Page<DoctorAvailability> page) {
+        List<DoctorAvailabilityResponseDTO> dtoList = toDtoList(page.getContent());
+        return new PageImpl<>(dtoList, page.getPageable(), page.getTotalElements());
+    }
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateEntityFromDto(DoctorAvailabilityRequestDTO dto, @MappingTarget DoctorAvailability doctorAvailability);
+}

--- a/src/main/java/com/sebastian/clinicbooking/mapper/DoctorMapper.java
+++ b/src/main/java/com/sebastian/clinicbooking/mapper/DoctorMapper.java
@@ -1,0 +1,56 @@
+package com.sebastian.clinicbooking.mapper;
+
+import java.util.List;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import com.sebastian.clinicbooking.DTO.doctor.DoctorRequestDTO;
+import com.sebastian.clinicbooking.DTO.doctor.DoctorResponseDTO;
+import com.sebastian.clinicbooking.DTO.doctor.DoctorSummaryDTO;
+import com.sebastian.clinicbooking.DTO.doctor.DoctorWithAppointmentDTO;
+import com.sebastian.clinicbooking.model.Doctor;
+
+@Mapper(componentModel = "spring", uses = {
+    SpecialityMapper.class,
+    HealthInsuranceMapper.class,
+    AppointmentMapper.class
+})
+public interface DoctorMapper {
+
+    Doctor toEntity(DoctorRequestDTO dto);
+
+    DoctorResponseDTO toDto(Doctor doctor);
+
+    DoctorSummaryDTO toSummaryDto(Doctor doctor);
+
+    DoctorWithAppointmentDTO toWithAppointmentDto(Doctor doctor);
+    
+    List<DoctorResponseDTO> toDtoList(List<Doctor> doctors);
+
+    List<DoctorSummaryDTO> toSummaryDtoList(List<Doctor> doctors);
+
+    List<DoctorWithAppointmentDTO> toWithAppointmentDtoList(List<Doctor> doctors);
+
+    default Page<DoctorResponseDTO> toDtoPage(Page<Doctor> page) {
+        List<DoctorResponseDTO> dtoList = toDtoList(page.getContent());
+        return new PageImpl<>(dtoList, page.getPageable(), page.getTotalElements());
+    }
+
+    default Page<DoctorWithAppointmentDTO> toWithAppointmentDtoPage(Page<Doctor> page) {
+        List<DoctorWithAppointmentDTO> dtoList = toWithAppointmentDtoList(page.getContent());
+        return new PageImpl<>(dtoList, page.getPageable(), page.getTotalElements());
+    }
+
+    default Page<DoctorSummaryDTO> toSummaryDtoPage(Page<Doctor> page) {
+        List<DoctorSummaryDTO> dtoList = toSummaryDtoList(page.getContent());
+        return new PageImpl<>(dtoList, page.getPageable(), page.getTotalElements());
+    }
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateEntityFromDto(DoctorRequestDTO dto, @MappingTarget Doctor doctor);
+}

--- a/src/main/java/com/sebastian/clinicbooking/mapper/HealthInsuranceMapper.java
+++ b/src/main/java/com/sebastian/clinicbooking/mapper/HealthInsuranceMapper.java
@@ -1,0 +1,42 @@
+package com.sebastian.clinicbooking.mapper;
+
+import java.util.List;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import com.sebastian.clinicbooking.DTO.healthInsurance.HealthInsuranceDetailDTO;
+import com.sebastian.clinicbooking.DTO.healthInsurance.HealthInsuranceRequestDTO;
+import com.sebastian.clinicbooking.DTO.healthInsurance.HealthInsuranceResponseDTO;
+import com.sebastian.clinicbooking.model.HealthInsurance;
+
+@Mapper(componentModel = "spring", uses = DoctorMapper.class)
+public interface HealthInsuranceMapper {
+    
+    HealthInsurance toEntity(HealthInsuranceRequestDTO dto);
+
+    HealthInsuranceResponseDTO toDto(HealthInsurance healthInsurance);
+
+    HealthInsuranceDetailDTO toDetailDto(HealthInsurance healthInsurance);
+    
+    List<HealthInsuranceResponseDTO> toDtoList(List<HealthInsurance> healthInsurances);
+
+    List<HealthInsuranceDetailDTO> toDetailDtoList(List<HealthInsurance> healthInsurances);
+
+    default Page<HealthInsuranceResponseDTO> toDtoPage(Page<HealthInsurance> page) {
+        List<HealthInsuranceResponseDTO> dtoList = toDtoList(page.getContent());
+        return new PageImpl<>(dtoList, page.getPageable(), page.getTotalElements());
+    }
+
+    default Page<HealthInsuranceDetailDTO> toDetailDtoPage(Page<HealthInsurance> page) {
+        List<HealthInsuranceDetailDTO> dtoList = toDetailDtoList(page.getContent());
+        return new PageImpl<>(dtoList, page.getPageable(), page.getTotalElements());
+    }
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateEntityFromDto(HealthInsuranceRequestDTO dto, @MappingTarget HealthInsurance healthInsurance);
+}

--- a/src/main/java/com/sebastian/clinicbooking/mapper/PatientMapper.java
+++ b/src/main/java/com/sebastian/clinicbooking/mapper/PatientMapper.java
@@ -1,0 +1,58 @@
+package com.sebastian.clinicbooking.mapper;
+
+import java.util.List;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import com.sebastian.clinicbooking.DTO.patient.PatientRequestDTO;
+import com.sebastian.clinicbooking.DTO.patient.PatientResponseDTO;
+import com.sebastian.clinicbooking.DTO.patient.PatientSummaryDTO;
+import com.sebastian.clinicbooking.DTO.patient.PatientWithAppointmentDTO;
+import com.sebastian.clinicbooking.model.Patient;
+
+
+@Mapper(componentModel = "spring", uses = {
+    AppointmentMapper.class,
+    HealthInsuranceMapper.class,
+})
+public interface PatientMapper {
+
+    Patient toEntity(PatientRequestDTO dto);
+
+    PatientResponseDTO toDto(Patient patient);
+
+    PatientSummaryDTO toSummaryDto(Patient patient);
+
+    PatientWithAppointmentDTO toWithAppointmentDto(Patient patient);
+
+    List<PatientResponseDTO> toDtoList(List<Patient> patients);
+
+    List<PatientSummaryDTO> toSummaryDtoList(List<Patient> patients);
+
+    List<PatientWithAppointmentDTO> toWithAppointmentDtoList(List<Patient> patients);
+
+
+    default Page<PatientResponseDTO> toDtoPage(Page<Patient> page) {
+        List<PatientResponseDTO> dtoList = toDtoList(page.getContent());
+        return new PageImpl<>(dtoList, page.getPageable(), page.getTotalElements());
+    }
+
+    default Page<PatientSummaryDTO> toDetailDtoPage(Page<Patient> page) {
+        List<PatientSummaryDTO> dtoList = toSummaryDtoList(page.getContent());
+        return new PageImpl<>(dtoList, page.getPageable(), page.getTotalElements());
+    }
+
+    default Page<PatientWithAppointmentDTO> toWithAppointmentDtoPage(Page<Patient> page) {
+        List<PatientWithAppointmentDTO> dtoList = toWithAppointmentDtoList(page.getContent());
+        return new PageImpl<>(dtoList, page.getPageable(), page.getTotalElements());
+    }
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateEntityFromDto(PatientRequestDTO dto, @MappingTarget Patient patient);
+
+}

--- a/src/main/java/com/sebastian/clinicbooking/mapper/SpecialityMapper.java
+++ b/src/main/java/com/sebastian/clinicbooking/mapper/SpecialityMapper.java
@@ -1,0 +1,43 @@
+package com.sebastian.clinicbooking.mapper;
+
+import java.util.List;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import com.sebastian.clinicbooking.DTO.speciality.SpecialityDetailDTO;
+import com.sebastian.clinicbooking.DTO.speciality.SpecialityRequestDTO;
+import com.sebastian.clinicbooking.DTO.speciality.SpecialityResponseDTO;
+import com.sebastian.clinicbooking.model.Speciality;
+
+@Mapper(componentModel = "spring", uses = DoctorMapper.class)
+public interface SpecialityMapper {
+
+    Speciality toEntity(SpecialityRequestDTO dto);
+
+    SpecialityRequestDTO toDto(Speciality speciality);
+
+    Speciality toDetailDto(Speciality speciality);
+
+    List<SpecialityResponseDTO> toDtoList(List<Speciality> specialities);
+
+    List<SpecialityDetailDTO> toDetailDtoList(List<Speciality> specialities);
+
+    default Page<SpecialityResponseDTO> toDtoPage(Page<Speciality> page) {
+        List<SpecialityResponseDTO> dtoList = toDtoList(page.getContent());
+        return new PageImpl<>(dtoList, page.getPageable(), page.getTotalElements());
+    }
+
+    default Page<SpecialityDetailDTO> toDetailDtoPage(Page<Speciality> page) {
+        List<SpecialityDetailDTO> dtoList = toDetailDtoList(page.getContent());
+        return new PageImpl<>(dtoList, page.getPageable(), page.getTotalElements());
+    }
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateEntityFromDto(SpecialityRequestDTO dto, @MappingTarget Speciality speciality);
+    
+}

--- a/src/main/java/com/sebastian/clinicbooking/mapper/SpecialityMapper.java
+++ b/src/main/java/com/sebastian/clinicbooking/mapper/SpecialityMapper.java
@@ -21,7 +21,7 @@ public interface SpecialityMapper {
 
     SpecialityRequestDTO toDto(Speciality speciality);
 
-    Speciality toDetailDto(Speciality speciality);
+    SpecialityDetailDTO toDetailDto(Speciality speciality);
 
     List<SpecialityResponseDTO> toDtoList(List<Speciality> specialities);
 

--- a/src/main/java/com/sebastian/clinicbooking/mapper/UserMapper.java
+++ b/src/main/java/com/sebastian/clinicbooking/mapper/UserMapper.java
@@ -1,0 +1,23 @@
+package com.sebastian.clinicbooking.mapper;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import com.sebastian.clinicbooking.DTO.user.UserResponseDTO;
+import com.sebastian.clinicbooking.model.User;
+
+@Mapper(componentModel = "spring")
+public interface UserMapper {
+
+    UserResponseDTO toDto(User user);
+
+    List<UserResponseDTO> toDtoList(List<User> users);
+
+    default Page<UserResponseDTO> toDetailDtoPage(Page<User> page) {
+        List<UserResponseDTO> dtoList = toDtoList(page.getContent());
+        return new PageImpl<>(dtoList, page.getPageable(), page.getTotalElements());
+    }
+}

--- a/src/main/java/com/sebastian/clinicbooking/model/Address.java
+++ b/src/main/java/com/sebastian/clinicbooking/model/Address.java
@@ -12,14 +12,16 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "addresses")
 @AllArgsConstructor
 @NoArgsConstructor
-@Data
+@Getter
+@Setter
 public class Address {
 
     @Id

--- a/src/main/java/com/sebastian/clinicbooking/model/Administrator.java
+++ b/src/main/java/com/sebastian/clinicbooking/model/Administrator.java
@@ -7,16 +7,18 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "administrators")
 @AllArgsConstructor
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-@Data
+@Getter
+@Setter
 public class Administrator extends User{
     
     @Id

--- a/src/main/java/com/sebastian/clinicbooking/model/Appointment.java
+++ b/src/main/java/com/sebastian/clinicbooking/model/Appointment.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -19,16 +20,20 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 @Entity
 @Table(name = "appointments")
 @AllArgsConstructor
 @NoArgsConstructor
-@Data
+@Getter
+@Setter
+@ToString(exclude = {"doctor", "patient", "clinic", "rescheduledFrom"})
+@EqualsAndHashCode(exclude = {"doctor", "patient", "clinic", "rescheduledFrom"})
 public class Appointment {
 
     @Id
@@ -36,6 +41,7 @@ public class Appointment {
     private Long id;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private AppointmentStatus status;
 
     @Column(name = "appointment_date_time", nullable = false)
@@ -50,17 +56,17 @@ public class Appointment {
     @Column(name = "confirmed", nullable = false)
     private boolean confirmed;
 
-    @ManyToOne
-    @JoinColumn(name = "doctor_id")
-    @ToString.Exclude
-    @EqualsAndHashCode.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "doctor_id", nullable = false)
     private Doctor doctor;
 
-    @ManyToOne
-    @JoinColumn(name = "patient_id")
-    @ToString.Exclude
-    @EqualsAndHashCode.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "patient_id", nullable = false)
     private Patient patient;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "clinic_id", nullable = false)
+    private Clinic clinic;
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
@@ -71,7 +77,7 @@ public class Appointment {
     private LocalDateTime updatedAt;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "cancelled_by")
+    @Column(name = "canceled_by")
     private Roles canceledBy;
 
     @Column(name = "cancellation_date")
@@ -80,9 +86,9 @@ public class Appointment {
     @Column(name = "cancellation_reason")
     private String cancellationReason;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "rescheduled_from_id", referencedColumnName = "id")
     private Appointment rescheduledFrom;
-
 }
+
 

--- a/src/main/java/com/sebastian/clinicbooking/model/Clinic.java
+++ b/src/main/java/com/sebastian/clinicbooking/model/Clinic.java
@@ -3,29 +3,33 @@ package com.sebastian.clinicbooking.model;
 import java.util.List;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 @Entity
 @Table(name = "clinics")
 @AllArgsConstructor
 @NoArgsConstructor
-@EqualsAndHashCode(callSuper = true)
-@Data
-public class Clinic extends User{
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true, exclude = {"doctors"})
+@ToString(callSuper = true, exclude = {"doctors"})
+public class Clinic extends User {
 
     @Column(name = "name", nullable = false, unique = true)
     private String name;
 
-    @OneToOne
-    @JoinColumn(name = "address_id", referencedColumnName = "id")
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "address_id", referencedColumnName = "id", nullable = false)
     private Address address;
 
     @Column(name = "contact_email", nullable = false, unique = true)
@@ -34,7 +38,7 @@ public class Clinic extends User{
     @Column(name = "description")
     private String description;
 
-    @OneToMany(mappedBy = "clinic")
-    @ToString.Exclude
+    @OneToMany(mappedBy = "clinic", fetch = FetchType.LAZY)
     private List<Doctor> doctors;
 }
+

--- a/src/main/java/com/sebastian/clinicbooking/model/Doctor.java
+++ b/src/main/java/com/sebastian/clinicbooking/model/Doctor.java
@@ -6,6 +6,7 @@ import java.util.List;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
@@ -13,16 +14,20 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Table(name = "doctors")
 @AllArgsConstructor
 @NoArgsConstructor
-@EqualsAndHashCode(callSuper = true)
-@Data
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true, exclude = {"specialities", "insurances", "clinic", "appointments"})
+@ToString(callSuper = true, exclude = {"specialities", "insurances", "clinic", "appointments"})
 public class Doctor extends User {
 
     @Column(name = "name", nullable = false)
@@ -40,27 +45,27 @@ public class Doctor extends User {
     @Column(name = "biography")
     private String biography;
 
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
-        name = "doctor_specialization",
+        name = "doctor_specialities",
         joinColumns = @JoinColumn(name = "doctor_id"),
-        inverseJoinColumns = @JoinColumn(name = "specialization_id")
+        inverseJoinColumns = @JoinColumn(name = "speciality_id")
     )
-    private List<Speciality> specialities;
+    private List<Speciality> specialities = new ArrayList<>();
 
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
         name = "doctor_insurance",
         joinColumns = @JoinColumn(name = "doctor_id"),
         inverseJoinColumns = @JoinColumn(name = "insurance_id")
     )
-    private List<HealthInsurance> insurances;
+    private List<HealthInsurance> insurances = new ArrayList<>();
 
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "clinic_id")
     private Clinic clinic;
 
     @OneToMany(mappedBy = "doctor", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Appointment> appointments = new ArrayList<>();
-    
 }
+

--- a/src/main/java/com/sebastian/clinicbooking/model/DoctorAvailability.java
+++ b/src/main/java/com/sebastian/clinicbooking/model/DoctorAvailability.java
@@ -11,29 +11,40 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Table(name = "doctors_availabilities")
 @AllArgsConstructor
 @NoArgsConstructor
-@Data
+@Getter
+@Setter
+@EqualsAndHashCode(exclude = "doctor")
+@ToString(exclude = "doctor")
 public class DoctorAvailability {
-    
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "doctor_id", nullable = false)
     private Doctor doctor;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "day_of_week", nullable = false)
     private DayOfWeek dayOfWeek;
 
     @Column(name = "start_time", nullable = false)

--- a/src/main/java/com/sebastian/clinicbooking/model/HealthInsurance.java
+++ b/src/main/java/com/sebastian/clinicbooking/model/HealthInsurance.java
@@ -15,14 +15,20 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Table(name = "health_insurances")
 @AllArgsConstructor
 @NoArgsConstructor
-@Data
+@Getter
+@Setter
+@EqualsAndHashCode(exclude = "doctors")
+@ToString(exclude = "doctors")
 public class HealthInsurance {
 
     @Id
@@ -46,3 +52,4 @@ public class HealthInsurance {
     @Column(name = "active", nullable = false)
     private boolean active = true;
 }
+

--- a/src/main/java/com/sebastian/clinicbooking/model/Patient.java
+++ b/src/main/java/com/sebastian/clinicbooking/model/Patient.java
@@ -18,16 +18,20 @@ import jakarta.persistence.ManyToMany;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Table(name = "patients")
 @AllArgsConstructor
 @NoArgsConstructor
-@EqualsAndHashCode(callSuper = true)
-@Data
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true, exclude = {"insurances", "appointments"})
+@ToString(callSuper = true, exclude = {"insurances", "appointments"})
 public class Patient extends User {
 
     @Column(name = "name", nullable = false)
@@ -41,7 +45,7 @@ public class Patient extends User {
 
     @Column(name = "birth_day", nullable = false)
     private LocalDate birthDate;
-    
+
     @Enumerated(EnumType.STRING)
     private Gender gender;
 

--- a/src/main/java/com/sebastian/clinicbooking/model/Speciality.java
+++ b/src/main/java/com/sebastian/clinicbooking/model/Speciality.java
@@ -15,14 +15,20 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Table(name = "specialities")
 @AllArgsConstructor
 @NoArgsConstructor
-@Data
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false, exclude = {"doctors"})
+@ToString(exclude = {"doctors"})
 public class Speciality {
 
     @Id
@@ -32,7 +38,7 @@ public class Speciality {
     @Column(name = "name", nullable = false, unique = true)
     private String name;
 
-    @ManyToMany(mappedBy = "specializations", fetch = FetchType.LAZY)
+    @ManyToMany(mappedBy = "specialities", fetch = FetchType.LAZY)
     private List<Doctor> doctors;
 
     @CreationTimestamp
@@ -42,5 +48,5 @@ public class Speciality {
     @UpdateTimestamp
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
-    
 }
+

--- a/src/main/java/com/sebastian/clinicbooking/model/User.java
+++ b/src/main/java/com/sebastian/clinicbooking/model/User.java
@@ -1,7 +1,6 @@
 package com.sebastian.clinicbooking.model;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
 
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -19,15 +18,19 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Table(name = "users")
 @Inheritance(strategy = InheritanceType.JOINED)
 @AllArgsConstructor
 @NoArgsConstructor
-@Data
+@Getter
+@Setter
+@ToString
 public class User {
 
     @Id
@@ -59,19 +62,5 @@ public class User {
 
     @Column(name = "active", nullable = false)
     private boolean active = true;
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-        User user = (User) o;
-        return Objects.equals(email, user.email);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(email);
-    }
 }
+


### PR DESCRIPTION
## Entity Refactoring and DTO Mappers Creation


1. **Refactored Entities:**
     - Optimized `@ManyToMany` and `@OneToMany` relationships with `fetch = FetchType.LAZY` to improve performance and prevent unnecessary eager loading.
     - Excluded entities in `@ToString` and `@EqualsAndHashCode` to avoid performance issues with large or circular data.
     - Ensured lists  are initialized as empty lists to avoid `NullPointerException`.

2. **DTO Mappers:**
   - Created mappers for each entity (`Doctor`, `Patient`, `Clinic`, etc.) to easily convert between entities and their corresponding DTOs.
   - The mappers use MapStruct (or custom mapping logic) to simplify object-to-object conversion and ensure consistency in the transformation of data.
